### PR TITLE
explicit form fields

### DIFF
--- a/cmsplugin_iframe/forms.py
+++ b/cmsplugin_iframe/forms.py
@@ -30,3 +30,6 @@ class IframeForm(forms.ModelForm):
 
     class Meta:
         model = IframePlugin
+        # Set fields list explicitly, because of Django 1.8 requiremets.
+        # We cannot use fields = '__all__' because of Django 1.5.
+        exclude = ('id',)


### PR DESCRIPTION
Set fields list explicitly, because of Django 1.8 requirements. In respond to #6 