### PR TITLE
Add in on_delete clause to work with more modern versions of Django

### DIFF
--- a/cmsplugin_iframe/migrations/0001_initial.py
+++ b/cmsplugin_iframe/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IframePlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('src', models.URLField()),
             ],
             options={


### PR DESCRIPTION
Django 2.0 and onward no longer automatically add "on_delete=CASCADE" to models, so it must be explicitly defined (https://docs.djangoproject.com/en/3.2/releases/2.0/#features-removed-in-2-0).